### PR TITLE
prevent crashes when proxy target url refuses connection. fixes #7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "steno",
-  "version": "0.1.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "steno",
   "version": "1.0.0-beta.1",
   "description": "developer tool for integration testing of Slack Apps",
+  "repository": "https://github.com/slackapi/steno.git",
   "bin": {
     "steno": "bin/cli.js"
   },

--- a/src/record/controller.ts
+++ b/src/record/controller.ts
@@ -93,7 +93,8 @@ export class RecordingController {
 }
 
 export function startRecordingController(
-  incomingRequestTargetUrl: string, controlPort: string, inPort: string, outPort: string, scenarioName: string, print: PrintFn, environment = '',
+  incomingRequestTargetUrl: string, controlPort: string, inPort: string, outPort: string, scenarioName: string,
+  print: PrintFn, environment = '',
 ): Promise<void> {
   // Slack-specific outgoing proxy configuration
   const outHostPrefix = environment ? `${environment}.` : '' ;
@@ -101,7 +102,8 @@ export function startRecordingController(
   const outTargetUrl = `https://${ outTargetHost }`;
 
   const controller = new RecordingController(
-    normalizeUrl(incomingRequestTargetUrl), outTargetUrl, normalizePort(controlPort), normalizePort(inPort), normalizePort(outPort), scenarioName, print
+    normalizeUrl(incomingRequestTargetUrl), outTargetUrl, normalizePort(controlPort), normalizePort(inPort),
+    normalizePort(outPort), scenarioName, print,
   );
   return controller.start();
 }

--- a/src/record/http-serializer.ts
+++ b/src/record/http-serializer.ts
@@ -108,6 +108,7 @@ export class HttpSerializer {
         this.pendingRequestDestinations.delete(responseInfo.requestId);
       });
     } else {
+      // TODO: the response may be ready before the request. set up a queue?
       log(`could not find destination for response with request id ${responseInfo.requestId}`);
     }
   }

--- a/src/replay/controller.ts
+++ b/src/replay/controller.ts
@@ -88,10 +88,10 @@ export class ReplayingController {
 }
 
 export function startReplayingController(
-  incomingRequestTargetUrl: string, controlPort: string, outPort: string, scenarioName: string, print: PrintFn
+  incomingRequestTargetUrl: string, controlPort: string, outPort: string, scenarioName: string, print: PrintFn,
 ): Promise<void> {
   const controller = new ReplayingController(
-    normalizeUrl(incomingRequestTargetUrl), normalizePort(controlPort), normalizePort(outPort), scenarioName, print
+    normalizeUrl(incomingRequestTargetUrl), normalizePort(controlPort), normalizePort(outPort), scenarioName, print,
   );
   return controller.start();
 }


### PR DESCRIPTION
###  Summary

steno will crash if no server is listening at appBaseUrl. this change prevents that crash.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/steno/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
