### PR TITLE
Better error messages for EADDRINUSE in HttpProxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf build",
     "watch": "tsc -w",
     "lint": "tslint --project . src/**/*.ts",
-    "start": "node bin/cli.js",
+    "start": "node bin/steno",
     "pkg": "npm run clean && npm run lint && npm run build && pkg --out-path pkg ."
   },
   "author": "Ankur Oberoi <aoberoi@gmail.com>",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,8 +143,9 @@ export default function main() {
   );
 
   analyticsPrompt()
-    .then(() => {
-      controller.start();
+    .then(() => controller.start())
+    .catch((error) => {
+      debug(`Terminating due to error: ${error.message}`);
     });
 }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -100,6 +100,19 @@ export function startServer(server: Server, port: string | number): Promise<void
   });
 }
 
+/**
+ * Allows a failed promise's error to be identified with a particular string as it gets thrown
+ *
+ * @param p original promise
+ * @param id an identifer that will be assigned to `error.identifier`
+ */
+export function assignErrorIdentifier<T>(p: Promise<T>, id: string): Promise<T> {
+  return p.catch((error) => {
+    error.identifier = id;
+    throw error;
+  });
+}
+
 
 /**
  * TypeScript-specific helper to resolve errors in functions where a return type is in the

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,4 +1,4 @@
-import { IncomingHttpHeaders, OutgoingHttpHeaders, request as httpReqFn } from 'http';
+import { IncomingHttpHeaders, OutgoingHttpHeaders, request as httpReqFn, Server } from 'http';
 import { request as httpsReqFn } from 'https';
 import cloneDeep = require('lodash.clonedeep'); // tslint:disable-line import-name
 import { ResponseInfo } from 'steno';
@@ -84,6 +84,22 @@ export function responseBodyToString(responseInfo: ResponseInfo): string | undef
   }
   return body;
 }
+
+/**
+ *
+ * @param server the server to be started
+ * @param port the port it is to be started on
+ */
+export function startServer(server: Server, port: string | number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+}
+
 
 /**
  * TypeScript-specific helper to resolve errors in functions where a return type is in the

--- a/src/record/http-proxy.ts
+++ b/src/record/http-proxy.ts
@@ -5,9 +5,8 @@ import { ClientRequest, createServer, IncomingMessage, RequestOptions, Server,
 import cloneDeep = require('lodash.clonedeep'); // tslint:disable-line import-name
 import rawBody = require('raw-body');
 import { format as urlFormat, parse as urlParse, Url, URL } from 'url';
-import { promisify } from 'util';
 import uuid = require('uuid/v4'); // tslint:disable-line import-name
-import { fixRequestHeaders, requestFunctionForTargetUrl } from '../common';
+import { fixRequestHeaders, requestFunctionForTargetUrl, startServer } from '../common';
 
 import { RequestInfo, ResponseInfo, NotOptionalIncomingHttpHeaders } from 'steno';
 
@@ -143,10 +142,10 @@ export class HttpProxy extends EventEmitter {
     });
   }
 
-  public listen(port: any): Promise<null> {
+  public listen(port: any): Promise<void> {
     log(`proxy listen on port ${port}`);
-    const serverListen = promisify(this.server.listen);
-    return serverListen.call(this.server, port);
+
+    return startServer(this.server, port);
   }
 
 }


### PR DESCRIPTION
###  Summary

Took the opportunity to track down some unhandled rejection code and fixed it. Also aggregated a few places where HTTP servers' `.listen()` method was being called but we needed to promisify the result, turned this into a common function.  Last but not least, made the `EADDRINUSE` error in `HttpProxy` clearer to understand and helps the user recover.

fixed #46 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/steno/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
