### PR TITLE
fixes incoming request order

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -147,6 +147,7 @@ export default function main() {
     .then(() => controller.start())
     .catch((error) => {
       debug(`Terminating due to error: ${error.message}`);
+      process.exit(1);
     });
 }
 

--- a/src/replay/interaction-catalog.ts
+++ b/src/replay/interaction-catalog.ts
@@ -323,17 +323,17 @@ export class InteractionCatalog extends EventEmitter {
   private checkTriggers() {
     log('check triggers');
     const sortedInteractions = this.interactions.slice()
-      .sort((a, b) => (b.timestamp as number) - (a.timestamp as number));
+      .sort((a, b) => (a.timestamp as number) - (b.timestamp as number));
     this.interactions
       .filter(interaction => !this.previouslyMatched.has(interaction.request.id))
       .filter(interaction => interaction.direction === 'incoming')
-      .sort((a, b) => (b.timestamp as number) - (a.timestamp as number))
+      .sort((a, b) => (a.timestamp as number) - (b.timestamp as number))
       .filter((unmatched) => {
         return sortedInteractions
           .filter((interaction) => {
             return (interaction.timestamp as number) < (unmatched.timestamp as number);
           })
-          .every(pi => this.previouslyMatched.has(pi.request.id));
+          .every(pi => pi.direction === 'incoming' || this.previouslyMatched.has(pi.request.id));
       })
       .forEach((i) => {
         this.previouslyMatched.add(i.request.id);


### PR DESCRIPTION
###  Summary

while investigating #32 i found an issue where incoming requests were a) only one incoming request was being replayed for each call to `checkTriggers()` when more than one were meant to be successive and b) where the order or successive incoming requests was opposite to the recorded order.

this PR fixes that issue.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/steno/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.
